### PR TITLE
Fixes display of page.comments condition

### DIFF
--- a/_posts/2014-02-03-jekyll-github-pages-poole.md
+++ b/_posts/2014-02-03-jekyll-github-pages-poole.md
@@ -152,7 +152,7 @@ blog. To do that, I modified the file [_layouts/default.html](https://github.com
 
 I then created a file [_includes/comments.html](https://github.com/joshualande/joshualande.github.io/blob/64d03b883b64dd8aedf30b903ecaae92a282955a/_includes/comments.html) which includes the code given to me by Disqus:
 {% highlight html %}
-{% if page.comments %}
+{{ "{% if page.comments " }}%}
 <!-- Add Disqus comments. -->
 <div id="disqus_thread"></div>
 <script type="text/javascript">
@@ -168,7 +168,7 @@ I then created a file [_includes/comments.html](https://github.com/joshualande/j
 </script>
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-{% endif %}
+{{ "{% endif " }}%}
 {% endhighlight %}
 By setting up the code this way, I can enabled commenting on a page-by-page basis. All I have to do is set "comments: True" in the YAML header of the post.
 


### PR DESCRIPTION
Currently these lines are not displayed but executed in the blog post.
